### PR TITLE
Home design and brandList logic

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     implementation "androidx.datastore:datastore-preferences:$preferences_datastore_version"
 
     //shopify
-    implementation ("com.shopify.mobilebuysdk:buy3:$shopify_version"){
+    implementation("com.shopify.mobilebuysdk:buy3:$shopify_version") {
         exclude group: "com.shopify.graphql.support"
     }
 }

--- a/app/src/main/java/com/example/shopify/helpers/ImageFromUrl.kt
+++ b/app/src/main/java/com/example/shopify/helpers/ImageFromUrl.kt
@@ -1,0 +1,83 @@
+package com.example.shopify.helpers
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.BrokenImage
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import coil.compose.SubcomposeAsyncImage
+import com.example.shopify.utils.shopifyLoading
+
+@Composable
+fun ImageFromUrl(url: String?) {
+    /*
+* SubcomposeAsyncImage(
+                modifier = Modifier
+                    .aspectRatio(1f, true)
+                    .weight(1f),
+                contentScale = ContentScale.Inside,
+                model = product.thumbnail,
+                contentDescription = null,
+                loading = {
+                    Box(
+                        Modifier
+                            .fillMaxSize()
+                            .shopifyLoading()
+                    )
+                },
+                error = {
+                    Icon(
+                        modifier = Modifier.fillMaxSize(),
+                        imageVector = Icons.Rounded.BrokenImage,
+                        tint = Color.Gray,
+                        contentDescription = null
+                    )
+                }
+            ) */
+    SubcomposeAsyncImage(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(2f),
+        model = url,
+        contentScale = ContentScale.Fit,
+        contentDescription = null,
+        loading = {
+            Box(modifier = Modifier
+                .fillMaxWidth()
+                .shopifyLoading())
+        },
+        error = {
+            Icon(
+                modifier = Modifier.fillMaxSize(),
+                imageVector = Icons.Rounded.BrokenImage,
+                tint = Color.Gray,
+                contentDescription = null
+            )
+        })
+}
+
+
+/* val painter = rememberImagePainter(
+     data = url
+
+ )
+ Box(
+     modifier = Modifier
+         .size(width = 200.dp, height = 100.dp)
+         .fillMaxSize()
+         .background(Color.White)
+ ) {
+     Image(
+         painter = painter,
+         contentDescription = null,
+         modifier = Modifier.fillMaxSize()
+     )
+ }
+}
+*/

--- a/app/src/main/java/com/example/shopify/model/repository/ShopifyRepository.kt
+++ b/app/src/main/java/com/example/shopify/model/repository/ShopifyRepository.kt
@@ -5,9 +5,11 @@ import com.example.shopify.ui.screen.auth.login.model.SignInUserInfo
 import com.example.shopify.ui.screen.auth.login.model.SignInUserResponseInfo
 import com.example.shopify.ui.screen.auth.registration.model.SignUpUserInfo
 import com.example.shopify.ui.screen.auth.registration.model.SignUpUserResponseInfo
+import com.example.shopify.ui.screen.home.model.Brand
 import kotlinx.coroutines.flow.Flow
 
 interface ShopifyRepository {
     fun signUp(userInfo: SignUpUserInfo): Flow<Resource<SignUpUserResponseInfo>>
     fun signIn(userInfo: SignInUserInfo): Flow<Resource<SignInUserResponseInfo>>
+    fun getBrands(): Flow<Resource<List<Brand>?>>
 }

--- a/app/src/main/java/com/example/shopify/model/repository/ShopifyRepositoryImpl.kt
+++ b/app/src/main/java/com/example/shopify/model/repository/ShopifyRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.example.shopify.ui.screen.auth.login.model.SignInUserInfo
 import com.example.shopify.ui.screen.auth.login.model.SignInUserResponseInfo
 import com.example.shopify.ui.screen.auth.registration.model.SignUpUserInfo
 import com.example.shopify.ui.screen.auth.registration.model.SignUpUserResponseInfo
+import com.example.shopify.ui.screen.home.model.Brand
 import com.shopify.buy3.GraphCallResult
 import com.shopify.buy3.GraphClient
 import com.shopify.buy3.Storefront
@@ -36,15 +37,17 @@ class ShopifyRepositoryImpl @Inject constructor(
         return enqueueAuth(query).mapResource(mapper::mapToSignInResponse)
     }
 
+    override fun getBrands(): Flow<Resource<List<Brand>?>> {
+        val query = queryGenerator.generateBrandQuery()
+        return query!!.enqueue().mapResource(mapper::mapToBrandResponse)
+    }
 
     private fun Storefront.QueryRootQuery.enqueue() = callbackFlow {
         val call = graphClient.queryGraph(this@enqueue).enqueue { result ->
             when (result) {
-                is GraphCallResult.Success ->
-                    trySend(Resource.Success(result.response))
+                is GraphCallResult.Success -> trySend(Resource.Success(result.response))
 
-                is GraphCallResult.Failure ->
-                    trySend(Resource.Error(result.error))
+                is GraphCallResult.Failure -> trySend(Resource.Error(result.error))
 
             }
         }

--- a/app/src/main/java/com/example/shopify/model/repository/generator/ShopifyQueryGenerator.kt
+++ b/app/src/main/java/com/example/shopify/model/repository/generator/ShopifyQueryGenerator.kt
@@ -7,4 +7,5 @@ import com.shopify.buy3.Storefront
 interface ShopifyQueryGenerator {
     fun generateSingUpQuery(userInfo: SignUpUserInfo): Storefront.MutationQuery
     fun generateSingInQuery(userInfo: SignInUserInfo): Storefront.MutationQuery
+    fun generateBrandQuery(): Storefront.QueryRootQuery?
 }

--- a/app/src/main/java/com/example/shopify/model/repository/generator/ShopifyQueryGeneratorImpl.kt
+++ b/app/src/main/java/com/example/shopify/model/repository/generator/ShopifyQueryGeneratorImpl.kt
@@ -5,7 +5,7 @@ import com.example.shopify.ui.screen.auth.registration.model.SignUpUserInfo
 import com.shopify.buy3.Storefront
 import javax.inject.Inject
 
-class ShopifyQueryGeneratorImpl @Inject constructor() :ShopifyQueryGenerator {
+class ShopifyQueryGeneratorImpl @Inject constructor() : ShopifyQueryGenerator {
     override fun generateSingUpQuery(userInfo: SignUpUserInfo): Storefront.MutationQuery =
         Storefront.mutation { rootQuery ->
             rootQuery.customerCreate(createSingUpCustomerCreateInput(userInfo)) { payload ->
@@ -30,6 +30,23 @@ class ShopifyQueryGeneratorImpl @Inject constructor() :ShopifyQueryGenerator {
                         .expiresAt()
                 }.customerUserErrors { userErrorQuery ->
                     userErrorQuery.field().message()
+                }
+            }
+        }
+
+    override fun generateBrandQuery(): Storefront.QueryRootQuery? =
+        Storefront.query { rootQuery: Storefront.QueryRootQuery ->
+            rootQuery.collections({ arg -> arg.first(10) }
+            ) { collectionConnectionQuery ->
+                collectionConnectionQuery.edges { collectionEdgeQuery ->
+                    collectionEdgeQuery
+                        .node { collectionQuery ->
+                            collectionQuery
+                                .title()
+                                .image {
+                                    it.url()
+                                }
+                        }
                 }
             }
         }

--- a/app/src/main/java/com/example/shopify/model/repository/mapper/ShopifyMapper.kt
+++ b/app/src/main/java/com/example/shopify/model/repository/mapper/ShopifyMapper.kt
@@ -2,10 +2,12 @@ package com.example.shopify.model.repository.mapper
 
 import com.example.shopify.ui.screen.auth.login.model.SignInUserResponseInfo
 import com.example.shopify.ui.screen.auth.registration.model.SignUpUserResponseInfo
+import com.example.shopify.ui.screen.home.model.Brand
 import com.shopify.buy3.GraphResponse
 import com.shopify.buy3.Storefront
 
 interface ShopifyMapper {
     fun map(response: GraphResponse<Storefront.Mutation>): SignUpUserResponseInfo
     fun mapToSignInResponse(response: GraphResponse<Storefront.Mutation>): SignInUserResponseInfo
+    fun mapToBrandResponse(response: GraphResponse<Storefront.QueryRoot>): List<Brand>?
 }

--- a/app/src/main/java/com/example/shopify/model/repository/mapper/ShopifyMapperImpl.kt
+++ b/app/src/main/java/com/example/shopify/model/repository/mapper/ShopifyMapperImpl.kt
@@ -2,13 +2,14 @@ package com.example.shopify.model.repository.mapper
 
 import com.example.shopify.ui.screen.auth.login.model.SignInUserResponseInfo
 import com.example.shopify.ui.screen.auth.registration.model.SignUpUserResponseInfo
+import com.example.shopify.ui.screen.home.model.Brand
 import com.shopify.buy3.GraphResponse
 import com.shopify.buy3.Storefront
 import javax.inject.Inject
 
 class ShopifyMapperImpl @Inject constructor() : ShopifyMapper {
 
-    override fun map(response:GraphResponse<Storefront.Mutation>) : SignUpUserResponseInfo {
+    override fun map(response: GraphResponse<Storefront.Mutation>): SignUpUserResponseInfo {
         val customer = response.data?.customerCreate?.customer
         return SignUpUserResponseInfo(
             customer?.firstName ?: "",
@@ -16,16 +17,24 @@ class ShopifyMapperImpl @Inject constructor() : ShopifyMapper {
             customer?.email ?: "",
             customer?.phone ?: "",
             customer?.id.toString(),
-            response.errors.getOrNull(0)?.message() ?:
-            response.data?.customerCreate?.customerUserErrors?.getOrNull(0)?.message)
+            response.errors.getOrNull(0)?.message()
+                ?: response.data?.customerCreate?.customerUserErrors?.getOrNull(0)?.message
+        )
     }
 
-    override fun mapToSignInResponse(response:GraphResponse<Storefront.Mutation>) : SignInUserResponseInfo {
+    override fun mapToSignInResponse(response: GraphResponse<Storefront.Mutation>): SignInUserResponseInfo {
         val customerAccessToken = response.data?.customerAccessTokenCreate?.customerAccessToken
         return SignInUserResponseInfo(
             customerAccessToken?.accessToken ?: "",
             customerAccessToken?.expiresAt,
-            response.data?.customerAccessTokenCreate?.customerUserErrors?.getOrNull(0)?.message ?: ""
+            response.data?.customerAccessTokenCreate?.customerUserErrors?.getOrNull(0)?.message
+                ?: ""
         )
+    }
+
+    override fun mapToBrandResponse(response: GraphResponse<Storefront.QueryRoot>): List<Brand>? {
+        return response.data?.collections?.edges?.drop(1)?.map {
+            Brand(title = it.node.title, url = it.node.image?.url)
+        }
     }
 }

--- a/app/src/main/java/com/example/shopify/ui/navigation/NavigationBarScreen.kt
+++ b/app/src/main/java/com/example/shopify/ui/navigation/NavigationBarScreen.kt
@@ -2,10 +2,35 @@ package com.example.shopify.ui.navigation
 
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Category
+import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.ShoppingCart
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.example.shopify.R
 
-sealed class NavigationBarScreen(val route: String, @StringRes val resourceId: Int, val icon: ImageVector){
-    object Home: NavigationBarScreen(route = "home", resourceId = R.string.home,icon = Icons.Rounded.Home)
+sealed class NavigationBarScreen(val route: String, @StringRes val resourceId: Int, val icon: ImageVector) {
+    object Home :
+        NavigationBarScreen(route = "home", resourceId = R.string.home, icon = Icons.Rounded.Home)
+
+    object Category : NavigationBarScreen(
+        route = "category", resourceId = R.string.category,
+        icon = Icons.Rounded.Category
+    )
+
+    object Favourite : NavigationBarScreen(
+        route = "favourite", resourceId = R.string.favourite,
+        icon = Icons.Rounded.Favorite
+    )
+
+    object Me : NavigationBarScreen(
+        route = "me", resourceId = R.string.me,
+        icon = Icons.Rounded.Person
+    )
+
+    object Cart : NavigationBarScreen(
+        route = "cart", resourceId = R.string.cart,
+        icon = Icons.Rounded.ShoppingCart
+    )
 }

--- a/app/src/main/java/com/example/shopify/ui/navigation/graph/HomeGraph.kt
+++ b/app/src/main/java/com/example/shopify/ui/navigation/graph/HomeGraph.kt
@@ -2,11 +2,40 @@ package com.example.shopify.ui.navigation.graph
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.example.shopify.ui.navigation.Graph
+import com.example.shopify.ui.navigation.NavigationBarScreen
+import com.example.shopify.ui.screen.cart.CartScreen
+import com.example.shopify.ui.screen.category.CategoriesScreen
+import com.example.shopify.ui.screen.favourite.FavoriteScreen
+import com.example.shopify.ui.screen.home.ui.HomeScreen
+import com.example.shopify.ui.screen.me.MeScreen
 
 @Composable
-fun HomeGraph(paddingValues: PaddingValues, navController: NavController) {
+fun HomeGraph(paddingValues: PaddingValues, navController: NavHostController) {
+    NavHost(
+        navController = navController,
+        route = Graph.ROOT,
+        startDestination = NavigationBarScreen.Home.route
+    ) {
+        composable(route = NavigationBarScreen.Home.route) {
+            HomeScreen(viewModel = hiltViewModel(), paddingValues)
+        }
+        composable(route = NavigationBarScreen.Category.route) {
+            CategoriesScreen()
+        }
+        composable(route = NavigationBarScreen.Favourite.route) {
+            FavoriteScreen()
+        }
+        composable(route = NavigationBarScreen.Me.route) {
+            MeScreen()
+        }
+        composable(route = NavigationBarScreen.Cart.route) {
+            CartScreen()
+        }
 
+    }
 }

--- a/app/src/main/java/com/example/shopify/ui/navigation/graph/ShopifyGraph.kt
+++ b/app/src/main/java/com/example/shopify/ui/navigation/graph/ShopifyGraph.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.example.shopify.ui.navigation.Graph
-import com.example.shopify.ui.screen.home.HomeScreen
+import com.example.shopify.ui.screen.home.ui.HomeNavigationBarScreen
 
 
 @Composable
@@ -13,7 +13,7 @@ fun ShopifyGraph(navController: NavHostController) {
     NavHost(
         navController = navController,
         route = Graph.ROOT,
-        startDestination = Graph.LANDING
+        startDestination = Graph.HOME
     ) {
         authGraph(navController)
 
@@ -22,7 +22,7 @@ fun ShopifyGraph(navController: NavHostController) {
         }
 
         composable(route = Graph.HOME){
-            HomeScreen()
+            HomeNavigationBarScreen()
         }
 
     }

--- a/app/src/main/java/com/example/shopify/ui/screen/cart/CartScreen.kt
+++ b/app/src/main/java/com/example/shopify/ui/screen/cart/CartScreen.kt
@@ -1,0 +1,18 @@
+package com.example.shopify.ui.screen.cart
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun CartScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "Cart Screen")
+    }
+}

--- a/app/src/main/java/com/example/shopify/ui/screen/category/CategoryScreen.kt
+++ b/app/src/main/java/com/example/shopify/ui/screen/category/CategoryScreen.kt
@@ -1,0 +1,18 @@
+package com.example.shopify.ui.screen.category
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun CategoriesScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "Categories Screen")
+    }
+}

--- a/app/src/main/java/com/example/shopify/ui/screen/common/Search.kt
+++ b/app/src/main/java/com/example/shopify/ui/screen/common/Search.kt
@@ -1,0 +1,92 @@
+package com.example.shopify.ui.screen.common
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.shopify.R
+import com.example.shopify.ui.theme.ShopifyTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchBarItem(
+    onSearch: (String) -> Unit
+) {
+    val searchQuery = remember { mutableStateOf("") }
+    Row(
+        modifier = Modifier
+            .background(Color.White)
+            .padding(vertical = 8.dp, horizontal = 10.dp)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = painterResource(R.drawable.shopfiy_logo),
+            contentDescription = "Logo",
+            modifier = Modifier
+                .size(60.dp)
+                .padding(end = 20.dp)
+        )
+        TextField(
+            value = searchQuery.value,
+            onValueChange = { searchQuery.value = it },
+            textStyle = TextStyle(color = Color.Black),
+            placeholder = {
+                Text(
+                    text = "Search",
+                    color = Color.Gray
+                )
+            },
+            singleLine = true,
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = "Search Icon",
+                    tint = Color.Gray
+                )
+            },
+            colors = TextFieldDefaults.textFieldColors(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent
+            ),
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Search
+            ),
+            keyboardActions = KeyboardActions(
+                onSearch = {
+                    onSearch(searchQuery.value)
+                }
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewSearchBar() {
+    ShopifyTheme {
+        SearchBarItem {}
+    }
+}

--- a/app/src/main/java/com/example/shopify/ui/screen/favourite/FavouriteScreen.kt
+++ b/app/src/main/java/com/example/shopify/ui/screen/favourite/FavouriteScreen.kt
@@ -1,0 +1,18 @@
+package com.example.shopify.ui.screen.favourite
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun FavoriteScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "Favorite Screen")
+    }
+}

--- a/app/src/main/java/com/example/shopify/ui/screen/home/model/Brand.kt
+++ b/app/src/main/java/com/example/shopify/ui/screen/home/model/Brand.kt
@@ -1,0 +1,3 @@
+package com.example.shopify.ui.screen.home.model
+
+data class Brand(val title: String, val url: String?)

--- a/app/src/main/java/com/example/shopify/ui/screen/home/ui/HomeNavigationBarScreen.kt
+++ b/app/src/main/java/com/example/shopify/ui/screen/home/ui/HomeNavigationBarScreen.kt
@@ -1,4 +1,4 @@
-package com.example.shopify.ui.screen.home
+package com.example.shopify.ui.screen.home.ui
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
@@ -25,21 +25,26 @@ import androidx.navigation.compose.rememberNavController
 import com.example.shopify.ui.navigation.NavigationBarScreen
 import com.example.shopify.ui.navigation.graph.HomeGraph
 
+
 private val items = listOf<NavigationBarScreen>(
-    NavigationBarScreen.Home
+    NavigationBarScreen.Home,
+    NavigationBarScreen.Category,
+    NavigationBarScreen.Favourite,
+    NavigationBarScreen.Me,
+    NavigationBarScreen.Cart
 )
 
-
 @Composable
-fun HomeScreen(navController: NavHostController = rememberNavController()) {
+fun HomeNavigationBarScreen(navController: NavHostController = rememberNavController()) {
     Scaffold(bottomBar = { HomeNavigationBar(navController = navController) }) { innerPadding ->
         HomeGraph(
             paddingValues = innerPadding,
             navController = navController
         )
-    }
-}
 
+    }
+
+}
 
 @Composable
 private fun HomeNavigationBar(navController: NavController) {
@@ -77,7 +82,7 @@ private fun RowScope.NavigationItem(
                 tint = if (selected) MaterialTheme.colorScheme.primary else LocalContentColor.current
             )
         },
-        label = { Text(stringResource(screen.resourceId)) },
+        label = { if (selected) Text(stringResource(screen.resourceId)) },
         selected = selected,
         onClick = {
             navController.navigate(screen.route) {

--- a/app/src/main/java/com/example/shopify/ui/screen/home/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/shopify/ui/screen/home/ui/HomeScreen.kt
@@ -1,0 +1,194 @@
+package com.example.shopify.ui.screen.home.ui
+
+import androidx.compose.animation.animateColor
+import androidx.compose.animation.core.AnimationConstants
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.repeatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.shopify.helpers.ImageFromUrl
+import com.example.shopify.ui.screen.common.LoadingContent
+import com.example.shopify.ui.screen.common.SearchBarItem
+import com.example.shopify.ui.screen.home.model.Brand
+import com.example.shopify.ui.screen.home.viewModel.BrandViewModel
+import com.example.shopify.ui.theme.ShopifyTheme
+import kotlinx.coroutines.delay
+
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun HomeScreen(viewModel: BrandViewModel, paddingValues: PaddingValues) {
+    viewModel.getBrandList()
+    val brandList by viewModel.brandList.collectAsState(initial = listOf())
+    LazyColumn(modifier = Modifier.padding(paddingValues)) {
+        stickyHeader {
+            SearchBarItem(onSearch = {})
+        }
+        item {
+            SalesCard()
+        }
+        item {
+            Text(
+                text = "Brands",
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(15.dp),
+                fontSize = 25.sp
+            )
+        }
+        if (brandList?.isNotEmpty()!!) {
+            for (i in 0..(brandList?.size ?: 0) step (2))
+                item {
+                    Row() {
+                        BrandListItem(item = brandList!![i])
+                        brandList!!.getOrNull(i + 1)?.let {
+                            BrandListItem(item = it)
+                        }
+                    }
+                }
+        } else {
+            item {
+                LoadingContent()
+            }
+
+        }
+    }
+}
+
+@Composable
+fun RowScope.BrandListItem(item: Brand) {
+    Card(
+        modifier = Modifier
+            .padding(10.dp)
+            .weight(1f),
+        shape = MaterialTheme.shapes.small,
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 15.dp
+        )
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            ImageFromUrl(url = item.url)
+            Spacer(modifier = Modifier.padding(bottom = 20.dp))
+            Text(
+                item.title, fontSize = 20.sp,
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+@Composable
+fun SalesCard() {
+    Card(
+        shape = MaterialTheme.shapes.small,
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 10.dp
+        ),
+        modifier = Modifier
+            .padding(20.dp)
+            .size(width = 400.dp, height = 150.dp)
+    ) {
+
+        var shakeState by remember { mutableStateOf(false) }
+        val infiniteTransition = rememberInfiniteTransition()
+
+        LaunchedEffect(Unit) {
+            while (true) {
+                shakeState = true
+                delay(100)
+                shakeState = false
+                delay(100)
+            }
+        }
+
+        val offsetX by animateFloatAsState(
+            targetValue = if (shakeState) 20f else 0f,
+            animationSpec = repeatable(
+                iterations = AnimationConstants.DefaultDurationMillis,
+                animation = tween(durationMillis = 300, easing = FastOutSlowInEasing)
+            )
+        )
+        val color by infiniteTransition.animateColor(
+            initialValue = Color.Red,
+            targetValue = Color.Green,
+            animationSpec = infiniteRepeatable(
+                animation = keyframes {
+                    durationMillis = 2000
+                    Color.Red at 0 with LinearOutSlowInEasing
+                    Color.Green at 500 with FastOutLinearInEasing
+                    Color.Blue at 1000
+                },
+                repeatMode = RepeatMode.Reverse
+            )
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "30% off",
+                fontSize = 50.sp,
+                color = color,
+                modifier = Modifier.offset(x = offsetX.dp),
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+
+}
+
+
+@Preview
+@Composable
+fun PreviewHomeScreen() {
+    ShopifyTheme {
+        HomeScreen(viewModel = hiltViewModel(), PaddingValues())
+    }
+}
+
+

--- a/app/src/main/java/com/example/shopify/ui/screen/home/viewModel/BrandViewModel.kt
+++ b/app/src/main/java/com/example/shopify/ui/screen/home/viewModel/BrandViewModel.kt
@@ -1,0 +1,36 @@
+package com.example.shopify.ui.screen.home.viewModel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.shopify.helpers.Resource
+import com.example.shopify.model.repository.ShopifyRepository
+import com.example.shopify.ui.screen.home.model.Brand
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BrandViewModel @Inject constructor(
+    private val repository: ShopifyRepository
+) : ViewModel() {
+    private var _brandList = MutableSharedFlow<List<Brand>?>()
+    val brandList: SharedFlow<List<Brand>?> = _brandList
+
+    init {
+        getBrandList()
+    }
+
+    fun getBrandList() {
+        viewModelScope.launch(Dispatchers.Default) {
+            repository.getBrands().collect {
+                when (it) {
+                    is Resource.Success -> _brandList.emit(it.data)
+                    is Resource.Error -> it.throwable
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/shopify/ui/screen/me/MeScreen.kt
+++ b/app/src/main/java/com/example/shopify/ui/screen/me/MeScreen.kt
@@ -1,0 +1,18 @@
+package com.example.shopify.ui.screen.me
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun MeScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "Me Screen")
+    }
+}

--- a/app/src/main/res/drawable/shopfiy_logo.xml
+++ b/app/src/main/res/drawable/shopfiy_logo.xml
@@ -1,15 +1,24 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="81.17dp"
-    android:height="112.51dp"
-    android:viewportWidth="80.17"
-    android:viewportHeight="112.51">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M45.44,35.16H23.1v32.37h22.34c8.94,0 16.18,-7.25 16.18,-16.18h0c0,-8.94 -7.25,-16.18 -16.18,-16.18Z"/>
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M20.02,32.37h22.34V0H20.02C11.08,0 3.83,7.25 3.83,16.18h0c0,8.94 7.25,16.18 16.18,16.18Z"/>
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M70.39,62.19m-5.33,0a5.33,5.33 0,1 1,10.66 0a5.33,5.33 0,1 1,-10.66 0"/>
+    android:width="95.849dp"
+    android:height="90.035dp"
+    android:viewportWidth="95.849"
+    android:viewportHeight="90.035">
+  <group>
+    <clip-path android:pathData="M0,-0L95.848,-0L95.848,90.035L0,90.035Z" />
+    <path
+        android:pathData="M55.47,46.876L25.683,46.876L25.683,90.034L55.47,90.034c11.917,-0 21.58,-9.661 21.58,-21.579C77.05,56.537 67.387,46.876 55.47,46.876"
+        android:fillColor="#000000"
+        android:strokeColor="#00000000"
+        android:fillType="nonZero" />
+    <path
+        android:pathData="M21.579,43.159L51.366,43.159L51.366,0L21.579,0c-11.917,-0 -21.579,9.661 -21.579,21.579C0.001,33.497 9.662,43.159 21.579,43.159"
+        android:fillColor="#000000"
+        android:strokeColor="#00000000"
+        android:fillType="nonZero" />
+    <path
+        android:pathData="m95.849,82.922c0,3.928 -3.184,7.112 -7.112,7.112 -3.929,-0 -7.113,-3.184 -7.113,-7.112 0,-3.928 3.184,-7.112 7.113,-7.112C92.665,75.81 95.849,78.994 95.849,82.922"
+        android:fillColor="#000000"
+        android:strokeColor="#00000000"
+        android:fillType="nonZero" />
+  </group>
 </vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,10 @@
     <string name="phone_not_formed_error">Hold up, it must be like (+201558653011)</string>
     <string name="nothing">must be like (+201558653011)</string>
     <string name="phone">Phone</string>
-    <string name="home">home</string>
-    <string name="back">back</string>
-
+    <string name="home">Home</string>
+    <string name="category">Category</string>
+    <string name="favourite">Favourite</string>
+    <string name="me">Me</string>
+    <string name="cart">Cart</string>
+    <string name="back">Back</string>
 </resources>


### PR DESCRIPTION
- add home graph with its screens
-design home screen consists of : 
1. searchBar and logo
<img width="209" alt="search" src="https://github.com/mohamed-ie/Shopify/assets/83082791/9be0f375-2b24-4043-9683-92cf45bb766d">

3. moving sale text 
https://github.com/mohamed-ie/Shopify/assets/83082791/6dd224ec-2565-42dd-81f2-7ea568bfe5b1

4. brand list and it has two states 
   - when the brand list is still loading
![homewithOutBrand](https://github.com/mohamed-ie/Shopify/assets/83082791/48e47bd5-c558-419f-bcf8-b99a4f27fd15)

   - when the brand list is already loaded
![brands](https://github.com/mohamed-ie/Shopify/assets/83082791/f966c322-b33b-40bd-950d-8086b15ed08f)

so the full screen will be 
![brands](https://github.com/mohamed-ie/Shopify/assets/83082791/c19207ef-ee0a-403d-a901-9080dde596b3)




